### PR TITLE
Index value was incorrectly using original index

### DIFF
--- a/src/Indexes.java
+++ b/src/Indexes.java
@@ -57,7 +57,7 @@ public class Indexes {
             
             
             names.add(path);
-            indexes.add(index);
+            indexes.add((long)i);
             originalIndexes.add(index);
             
             


### PR DESCRIPTION
The same value (index) was being used for both indexes and originalIndexes. This caused both columns to print the same value in the imagesdata.csv. By using the i variable, we utilize the correct value.