### PR TITLE
Gradle: fix building PicasaFaces script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,3 +21,5 @@ task picasaFacesScripts(type: CreateStartScripts) {
     outputDir = new File(project.buildDir, 'scripts')
     classpath = jar.outputs.files + project.configurations.runtime
 }
+
+startScripts.dependsOn picasaFacesScripts


### PR DESCRIPTION
60d1df36 is wrong, it prevents the extra scripts being built at all. I
tested in a dirty build tree, which made everything appear to work.

With this change, PicasaFaces and PicasaFaces.bat are actually built,
and get included in the zip and tar archives exactly once.

Sorry about that! I was debugging this but forgot to mention this problem on the last pull request.
